### PR TITLE
Set scope=provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,15 +74,10 @@
     </dependency>
 
     <dependency>
-      <groupId>io.opentracing</groupId>
-      <artifactId>opentracing-noop</artifactId>
-      <version>${opentracing.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
       <version>${hazelcast.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target library to "provided". It is a guarantee that the integrating codebase will provide this library, otherwise the instrumentation plugin would be moot if the codebase does not already have this library.

Also remove `opentracing-noop` dependency as it's not used.